### PR TITLE
Adding an option to process messages that were published into SQS by a SNS topic

### DIFF
--- a/lib/logstash/inputs/s3sqs.rb
+++ b/lib/logstash/inputs/s3sqs.rb
@@ -86,6 +86,8 @@ class LogStash::Inputs::S3SQS < LogStash::Inputs::Threadable
 
   # Name of the SQS Queue to pull messages from. Note that this is just the name of the queue, not the URL or ARN.
   config :queue, :validate => :string, :required => true
+  # If the message flux is S3 -> SNS -> SQS
+  config :from_sns, :validate => :boolean, :default => false
 
   attr_reader :poller
   attr_reader :s3
@@ -122,6 +124,9 @@ class LogStash::Inputs::S3SQS < LogStash::Inputs::Threadable
     hash = JSON.parse message.body
     # there may be test events sent from the s3 bucket which won't contain a Records array,
     # we will skip those events and remove them from queue
+    if @from_sns then
+      hash = JSON.parse hash['Message']
+    end
     if hash['Records'] then
       # typically there will be only 1 record per event, but since it is an array we will
       # treat it as if there could be more records


### PR DESCRIPTION
Unfortunately S3 notifications won't allow multiple destinations with the same trigger, like on object create, so we send a notification to a SNS topic, that sends to multiple destinations, SQS being one of those.

So I've added an option that allows this plugin to process data that were published into SQS by a SNS topic. Allowing the message flux S3 -> SNS -> SQS